### PR TITLE
Set file permissions when creating files

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -10316,7 +10316,7 @@ async function getGithubKeys(octokit) {
 }
 async function writeAuthorizedKeys(homedir, keys) {
     const authorizedKeysPath = external_path_default().resolve(external_path_default().join(homedir, '.ssh', 'authorized_keys'));
-    external_fs_default().mkdirSync(external_path_default().dirname(authorizedKeysPath), { recursive: true });
+    external_fs_default().mkdirSync(external_path_default().dirname(authorizedKeysPath), { recursive: true, mode: 0o700 });
     external_fs_default().writeFileSync(authorizedKeysPath, keys);
     external_fs_default().chmodSync(external_path_default().dirname(authorizedKeysPath), 0o700);
     external_fs_default().chmodSync(authorizedKeysPath, 0o644);

--- a/src/add-github-ssh-key.ts
+++ b/src/add-github-ssh-key.ts
@@ -27,9 +27,7 @@ export async function writeAuthorizedKeys(
   const authorizedKeysPath = path.resolve(
     path.join(homedir, '.ssh', 'authorized_keys')
   )
-  fs.mkdirSync(path.dirname(authorizedKeysPath), {recursive: true})
-  fs.writeFileSync(authorizedKeysPath, keys)
-  fs.chmodSync(path.dirname(authorizedKeysPath), 0o700)
-  fs.chmodSync(authorizedKeysPath, 0o644)
+  fs.mkdirSync(path.dirname(authorizedKeysPath), {recursive: true, mode: 0o700})
+  fs.writeFileSync(authorizedKeysPath, keys, {mode: 0o400, flag: 'wx'})
   return authorizedKeysPath
 }


### PR DESCRIPTION
Consolidates the creation of files with setting permissions instead of
relying on chmodSync (which might not work as intended on windows)

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>