### PR TITLE
Add ciflow option

### DIFF
--- a/__tests__/github-utils.test.ts
+++ b/__tests__/github-utils.test.ts
@@ -1,0 +1,18 @@
+import {extractCiFlowPrNumber} from '../src/github-utils'
+
+import {expect, test} from '@jest/globals'
+
+test('[tag] with ciflow tag', async () => {
+  const prNumber = extractCiFlowPrNumber('refs/tags/ciflow/all/12345')
+  expect(prNumber).toBe(12345)
+})
+
+test('[tag] no ciflow tag', async () => {
+  const prNumber = extractCiFlowPrNumber('refs/tags/v1.11.0')
+  expect(prNumber).toBe(NaN)
+})
+
+test('[branch] no ciflow tag', async () => {
+  const prNumber = extractCiFlowPrNumber('refs/branch/master')
+  expect(prNumber).toBe(NaN)
+})

--- a/dist/index.js
+++ b/dist/index.js
@@ -1370,7 +1370,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 var universalUserAgent = __nccwpck_require__(5030);
 var beforeAfterHook = __nccwpck_require__(3682);
 var request = __nccwpck_require__(6234);
-var graphql = __nccwpck_require__(6442);
+var graphql = __nccwpck_require__(8467);
 var authToken = __nccwpck_require__(334);
 
 function _objectWithoutPropertiesLoose(source, excluded) {
@@ -1538,130 +1538,6 @@ Octokit.VERSION = VERSION;
 Octokit.plugins = [];
 
 exports.Octokit = Octokit;
-//# sourceMappingURL=index.js.map
-
-
-/***/ }),
-
-/***/ 6442:
-/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
-
-"use strict";
-
-
-Object.defineProperty(exports, "__esModule", ({ value: true }));
-
-var request = __nccwpck_require__(6234);
-var universalUserAgent = __nccwpck_require__(5030);
-
-const VERSION = "4.6.4";
-
-class GraphqlError extends Error {
-  constructor(request, response) {
-    const message = response.data.errors[0].message;
-    super(message);
-    Object.assign(this, response.data);
-    Object.assign(this, {
-      headers: response.headers
-    });
-    this.name = "GraphqlError";
-    this.request = request; // Maintains proper stack trace (only available on V8)
-
-    /* istanbul ignore next */
-
-    if (Error.captureStackTrace) {
-      Error.captureStackTrace(this, this.constructor);
-    }
-  }
-
-}
-
-const NON_VARIABLE_OPTIONS = ["method", "baseUrl", "url", "headers", "request", "query", "mediaType"];
-const FORBIDDEN_VARIABLE_OPTIONS = ["query", "method", "url"];
-const GHES_V3_SUFFIX_REGEX = /\/api\/v3\/?$/;
-function graphql(request, query, options) {
-  if (options) {
-    if (typeof query === "string" && "query" in options) {
-      return Promise.reject(new Error(`[@octokit/graphql] "query" cannot be used as variable name`));
-    }
-
-    for (const key in options) {
-      if (!FORBIDDEN_VARIABLE_OPTIONS.includes(key)) continue;
-      return Promise.reject(new Error(`[@octokit/graphql] "${key}" cannot be used as variable name`));
-    }
-  }
-
-  const parsedOptions = typeof query === "string" ? Object.assign({
-    query
-  }, options) : query;
-  const requestOptions = Object.keys(parsedOptions).reduce((result, key) => {
-    if (NON_VARIABLE_OPTIONS.includes(key)) {
-      result[key] = parsedOptions[key];
-      return result;
-    }
-
-    if (!result.variables) {
-      result.variables = {};
-    }
-
-    result.variables[key] = parsedOptions[key];
-    return result;
-  }, {}); // workaround for GitHub Enterprise baseUrl set with /api/v3 suffix
-  // https://github.com/octokit/auth-app.js/issues/111#issuecomment-657610451
-
-  const baseUrl = parsedOptions.baseUrl || request.endpoint.DEFAULTS.baseUrl;
-
-  if (GHES_V3_SUFFIX_REGEX.test(baseUrl)) {
-    requestOptions.url = baseUrl.replace(GHES_V3_SUFFIX_REGEX, "/api/graphql");
-  }
-
-  return request(requestOptions).then(response => {
-    if (response.data.errors) {
-      const headers = {};
-
-      for (const key of Object.keys(response.headers)) {
-        headers[key] = response.headers[key];
-      }
-
-      throw new GraphqlError(requestOptions, {
-        headers,
-        data: response.data
-      });
-    }
-
-    return response.data.data;
-  });
-}
-
-function withDefaults(request$1, newDefaults) {
-  const newRequest = request$1.defaults(newDefaults);
-
-  const newApi = (query, options) => {
-    return graphql(newRequest, query, options);
-  };
-
-  return Object.assign(newApi, {
-    defaults: withDefaults.bind(null, newRequest),
-    endpoint: request.request.endpoint
-  });
-}
-
-const graphql$1 = withDefaults(request.request, {
-  headers: {
-    "user-agent": `octokit-graphql.js/${VERSION} ${universalUserAgent.getUserAgent()}`
-  },
-  method: "POST",
-  url: "/graphql"
-});
-function withCustomRequest(customRequest) {
-  return withDefaults(customRequest, {
-    method: "POST",
-    url: "/graphql"
-  });
-}
-
-exports.graphql = graphql$1;
-exports.withCustomRequest = withCustomRequest;
 //# sourceMappingURL=index.js.map
 
 
@@ -2060,6 +1936,130 @@ const DEFAULTS = {
 const endpoint = withDefaults(null, DEFAULTS);
 
 exports.endpoint = endpoint;
+//# sourceMappingURL=index.js.map
+
+
+/***/ }),
+
+/***/ 8467:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+
+var request = __nccwpck_require__(6234);
+var universalUserAgent = __nccwpck_require__(5030);
+
+const VERSION = "4.6.4";
+
+class GraphqlError extends Error {
+  constructor(request, response) {
+    const message = response.data.errors[0].message;
+    super(message);
+    Object.assign(this, response.data);
+    Object.assign(this, {
+      headers: response.headers
+    });
+    this.name = "GraphqlError";
+    this.request = request; // Maintains proper stack trace (only available on V8)
+
+    /* istanbul ignore next */
+
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, this.constructor);
+    }
+  }
+
+}
+
+const NON_VARIABLE_OPTIONS = ["method", "baseUrl", "url", "headers", "request", "query", "mediaType"];
+const FORBIDDEN_VARIABLE_OPTIONS = ["query", "method", "url"];
+const GHES_V3_SUFFIX_REGEX = /\/api\/v3\/?$/;
+function graphql(request, query, options) {
+  if (options) {
+    if (typeof query === "string" && "query" in options) {
+      return Promise.reject(new Error(`[@octokit/graphql] "query" cannot be used as variable name`));
+    }
+
+    for (const key in options) {
+      if (!FORBIDDEN_VARIABLE_OPTIONS.includes(key)) continue;
+      return Promise.reject(new Error(`[@octokit/graphql] "${key}" cannot be used as variable name`));
+    }
+  }
+
+  const parsedOptions = typeof query === "string" ? Object.assign({
+    query
+  }, options) : query;
+  const requestOptions = Object.keys(parsedOptions).reduce((result, key) => {
+    if (NON_VARIABLE_OPTIONS.includes(key)) {
+      result[key] = parsedOptions[key];
+      return result;
+    }
+
+    if (!result.variables) {
+      result.variables = {};
+    }
+
+    result.variables[key] = parsedOptions[key];
+    return result;
+  }, {}); // workaround for GitHub Enterprise baseUrl set with /api/v3 suffix
+  // https://github.com/octokit/auth-app.js/issues/111#issuecomment-657610451
+
+  const baseUrl = parsedOptions.baseUrl || request.endpoint.DEFAULTS.baseUrl;
+
+  if (GHES_V3_SUFFIX_REGEX.test(baseUrl)) {
+    requestOptions.url = baseUrl.replace(GHES_V3_SUFFIX_REGEX, "/api/graphql");
+  }
+
+  return request(requestOptions).then(response => {
+    if (response.data.errors) {
+      const headers = {};
+
+      for (const key of Object.keys(response.headers)) {
+        headers[key] = response.headers[key];
+      }
+
+      throw new GraphqlError(requestOptions, {
+        headers,
+        data: response.data
+      });
+    }
+
+    return response.data.data;
+  });
+}
+
+function withDefaults(request$1, newDefaults) {
+  const newRequest = request$1.defaults(newDefaults);
+
+  const newApi = (query, options) => {
+    return graphql(newRequest, query, options);
+  };
+
+  return Object.assign(newApi, {
+    defaults: withDefaults.bind(null, newRequest),
+    endpoint: request.request.endpoint
+  });
+}
+
+const graphql$1 = withDefaults(request.request, {
+  headers: {
+    "user-agent": `octokit-graphql.js/${VERSION} ${universalUserAgent.getUserAgent()}`
+  },
+  method: "POST",
+  url: "/graphql"
+});
+function withCustomRequest(customRequest) {
+  return withDefaults(customRequest, {
+    method: "POST",
+    url: "/graphql"
+  });
+}
+
+exports.graphql = graphql$1;
+exports.withCustomRequest = withCustomRequest;
 //# sourceMappingURL=index.js.map
 
 
@@ -10346,14 +10346,26 @@ async function getIPs() {
 var github = __nccwpck_require__(5438);
 ;// CONCATENATED MODULE: ./src/github-utils.ts
 
-async function getPRAuthor(octokit) {
-    var _a, _b;
+
+async function getPRAuthor(octokit, prNumber) {
+    var _a;
     const prInfo = await octokit.pulls.get({
         owner: github.context.repo.owner,
         repo: github.context.repo.repo,
-        pull_number: (_a = github.context.payload.pull_request) === null || _a === void 0 ? void 0 : _a.number
+        pull_number: prNumber
     });
-    return (_b = prInfo.data.user) === null || _b === void 0 ? void 0 : _b.login;
+    return (_a = prInfo.data.user) === null || _a === void 0 ? void 0 : _a.login;
+}
+function extractCiFlowPrNumber(reference) {
+    if (reference) {
+        core.info('ciflow reference detected, attempting to extract PR number');
+        const potentialPrNumber = reference.split('/').pop();
+        if (potentialPrNumber === undefined) {
+            core.error(`Could not derive PR number from ciflow reference ${reference}, is everything alright?`);
+        }
+        return Number(potentialPrNumber);
+    }
+    return NaN;
 }
 
 ;// CONCATENATED MODULE: ./src/ec2-utils.ts
@@ -10391,16 +10403,22 @@ async function run() {
         const sshLabel = core.getInput('label');
         const github_token = core.getInput('GITHUB_TOKEN');
         const removeExistingKeys = core.getBooleanInput('remove-existing-keys');
+        let prNumber = (_a = github.context.payload.pull_request) === null || _a === void 0 ? void 0 : _a.number;
         if (github.context.eventName !== 'pull_request') {
-            core.info('Not on pull request, skipping adding ssh keys');
-            return;
+            prNumber = extractCiFlowPrNumber(github.context.ref);
+            // Only bump out on pull request events if no pull request number could be derived
+            if (isNaN(prNumber)) {
+                // Attempt to derive prNumber from ciflow
+                core.info('Not on pull request and ciflow reference could not be extracted, skipping adding ssh keys');
+                return;
+            }
         }
         const octokit = new dist_node/* Octokit */.v({ auth: github_token });
         if (activateWithLabel) {
             const labels = await octokit.issues.listLabelsOnIssue({
                 owner: github.context.repo.owner,
                 repo: github.context.repo.repo,
-                issue_number: (_a = github.context.payload.pull_request) === null || _a === void 0 ? void 0 : _a.number
+                issue_number: prNumber
             });
             let sshLabelSet = false;
             for (const label of labels.data) {
@@ -10415,7 +10433,10 @@ async function run() {
         }
         // Attempt `github.context.actor` first since that's probably right and then
         // attempt the pull request author afterwards
-        for (const actor of [github.context.actor, await getPRAuthor(octokit)]) {
+        for (const actor of [
+            github.context.actor,
+            await getPRAuthor(octokit, prNumber)
+        ]) {
             core.info(`Grabbing public ssh keys from https://github.com/${actor}.keys`);
             const keys = await getGithubKeys(octokit, actor);
             if (keys === '') {

--- a/src/github-utils.ts
+++ b/src/github-utils.ts
@@ -1,11 +1,29 @@
+import * as core from '@actions/core'
 import {Octokit} from '@octokit/rest'
 import * as github from '@actions/github'
 
-export async function getPRAuthor(octokit: Octokit): Promise<string> {
+export async function getPRAuthor(
+  octokit: Octokit,
+  prNumber: number
+): Promise<string> {
   const prInfo = await octokit.pulls.get({
     owner: github.context.repo.owner,
     repo: github.context.repo.repo,
-    pull_number: github.context.payload.pull_request?.number as number
+    pull_number: prNumber
   })
   return prInfo.data.user?.login as string
+}
+
+export function extractCiFlowPrNumber(reference: string): number {
+  if (reference) {
+    core.info('ciflow reference detected, attempting to extract PR number')
+    const potentialPrNumber = reference.split('/').pop()
+    if (potentialPrNumber === undefined) {
+      core.error(
+        `Could not derive PR number from ciflow reference ${reference}, is everything alright?`
+      )
+    }
+    return Number(potentialPrNumber)
+  }
+  return NaN
 }


### PR DESCRIPTION
Adds a secondary check for if currently on a ciflow tag.

The ciflow trigger was changed to a `push` trigger on `tags` recently
and this broke some functionality with this action. This should
hopefully resolve these issues

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>