### PR TITLE
Update node12 to node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,5 +17,5 @@ inputs:
     description: 'Removes existing keys at ~/.ssh/authorized_keys before adding new ones'
     default: true
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
As GH is deprecating it, see https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/